### PR TITLE
chore: make sure that cargo-fmt and clippy are installed

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -5,7 +5,7 @@ cargo-machete = "ubi:bnjbvr/cargo-machete"
 actionlint = "latest"
 python = "3.13"
 ruff = "latest"
-rust = "stable"
+rust = { version = "stable", profile = "default" }
 uv = "latest"
 
 [task_config]


### PR DESCRIPTION
This in theory should fix the linter failures, although it's confusing that it wasn't installed by default.