### PR TITLE
ci: replace `cargo-machete` with `cargo-shear`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
         with:
           experimental: true
           tool_versions: |
-            cargo-machete latest
+            cargo-shear latest
             taplo latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.tasks/rust.toml
+++ b/.tasks/rust.toml
@@ -5,9 +5,9 @@ description = "Lints Rust files with Clippy"
 run = "cargo clippy --all-features --all-targets --workspace"
 
 ["lint:rust-unused-deps"]
-tools.cargo-machete = "latest"
+tools.cargo-shear = "latest"
 description = "Checks if there are any unused crate dependencies declared"
-run = "cargo machete"
+run = "cargo shear"
 
 ["lint:rustfmt"]
 description = "Checks if Rust files are formatted correctly"

--- a/mise.lock
+++ b/mise.lock
@@ -1,12 +1,12 @@
-[tools.actionlint]
+[[tools.actionlint]]
 version = "1.7.7"
 backend = "aqua:rhysd/actionlint"
 
-[tools.python]
+[[tools.python]]
 version = "3.13.5"
 backend = "core:python"
 
-[tools.ruff]
+[[tools.ruff]]
 version = "0.12.7"
 backend = "aqua:astral-sh/ruff"
 
@@ -15,11 +15,11 @@ checksum = "sha256:58aeb49137d0a9df810ba26c778d10d612f8c1439439527a6a95c90ea318c
 size = 13001529
 url = "https://github.com/astral-sh/ruff/releases/download/0.12.7/ruff-x86_64-unknown-linux-musl.tar.gz"
 
-[tools.rust]
+[[tools.rust]]
 version = "stable"
 backend = "core:rust"
 
-[tools.uv]
+[[tools.uv]]
 version = "0.8.4"
 backend = "aqua:astral-sh/uv"
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [alias]
-cargo-machete = "ubi:bnjbvr/cargo-machete"
+cargo-shear = "github:Boshen/cargo-shear"
 
 [tools]
 actionlint = "latest"


### PR DESCRIPTION
`cargo-shear` seems better for my use case.

`mise.lock` change is due to using an updated `mise` (lock file is experimental/in flux).